### PR TITLE
Create switchmanager.ts

### DIFF
--- a/classes/switchmanager.ts
+++ b/classes/switchmanager.ts
@@ -1,0 +1,20 @@
+namespace switchblock {
+  class SwitchManager {
+      private switches: { [name: string]: SwitchContext } = {};
+  
+      create(name: string): SwitchContext {
+          const ctx = new SwitchContext();
+          this.switches[name] = ctx;
+          return ctx;
+      }
+  
+      get(name: string): SwitchContext {
+          return this.switches[name];
+      }
+  
+      debug(name: string): void {
+          const ctx = this.switches[name];
+          console.log(`Switch "${name}" has ${ctx.caseCount()} cases`);
+      }
+  }
+}


### PR DESCRIPTION
and populate it so we no longer need a shared object that is "dumb" - instead we can "enlighten" it by transforming it into a manager for the SwitchContext instances