### PR TITLE
Update switchmanager.ts - same issue as with switchcontext.ts

### DIFF
--- a/classes/switchmanager.ts
+++ b/classes/switchmanager.ts
@@ -2,7 +2,7 @@ import { SwitchContext } from "../classes/switchcontext"
 
 //namespace classes {
 
-export class SwitchManager {
+class SwitchManager {
   private Switches: { [Name: string]: SwitchContext } = {};
 
   create(name: string): SwitchContext {


### PR DESCRIPTION
Removing export from class because, as it states, all top-level classes auto-export...even though the namespace added to it is in fact not top-level (`./classes/SwitchManager`)